### PR TITLE
Add lightning ports configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # lightning-dissector
+
 A wireshark plugin to analyze communication between Lightning Network nodes
 
-![](https://user-images.githubusercontent.com/12756700/45472759-1b79fe00-b770-11e8-812b-f73e8cd18ab6.png)
+![Sample screenshot of the dissector running in wireshark](https://user-images.githubusercontent.com/12756700/45472759-1b79fe00-b770-11e8-812b-f73e8cd18ab6.png)
 
 ## Installation
+
 First of all, you have to make sure that luarocks for Lua 5.2 is installed.  
 [Here is how to build it](https://github.com/luarocks/luarocks/wiki/Installation-instructions-for-Unix). (You should set --lua-version=5.2 option when doing `./configure`.)  
 And you'll need Lua library and headers. (if Ubuntu you can get it by `apt install lua5.2 liblua5.2-dev`)
 
 Other requirements:
+
 - libpcre (`apt install libpcre3-dev`)
 
 ```bash
@@ -19,8 +22,9 @@ mkdir -p ~/.config/wireshark/plugins
 ln -s ~/.luarocks/share/lua/5.2/lightning-dissector/wireshark-plugin.lua ~/.config/wireshark/plugins/lightning-dissector.lua
 ```
 
-When a big BOLT message comes, lightning-dissector outputs a big message to Wireshark. (#25)    
+When a big BOLT message comes, lightning-dissector outputs a big message to Wireshark. (#25)
 Therefore, you might have to apply these patches to Wireshark source code.
+
 ```diff
 diff --git epan/proto.h epan/proto.h
 index afe8dae6e2..81e1e74a60 100644
@@ -28,12 +32,12 @@ index afe8dae6e2..81e1e74a60 100644
 +++ epan/proto.h
 @@ -60,7 +60,7 @@ extern "C" {
  WS_DLL_PUBLIC int hf_text_only;
- 
+
  /** the maximum length of a protocol field string representation */
--#define ITEM_LABEL_LENGTH	240
-+#define ITEM_LABEL_LENGTH	10000
- 
- #define ITEM_LABEL_UNKNOWN_STR	"Unknown"
+-#define ITEM_LABEL_LENGTH  240
++#define ITEM_LABEL_LENGTH  10000
+
+ #define ITEM_LABEL_UNKNOWN_STR  "Unknown"
 ```
 
 ## Setup
@@ -49,6 +53,7 @@ you need to configure the dissector to inspect those ports.
 Go to `Edit Menu -> Preferences -> Protocols -> LIGHTNING` to change the ports inspected by the dissector.
 
 ### c-lightning (beta)
+
 ```bash
 git clone https://github.com/arowser/lightning -b dissector
 cd lightning
@@ -58,6 +63,7 @@ make install  # optional
 ```
 
 ### Eclair
+
 Set loglevel to DEBUG.  
 lightning-dissector searches debug log for decryption key.
 
@@ -68,7 +74,9 @@ sed -i 's/<root level="INFO">/<root level="DEBUG">/' eclair-node/src/main/resour
 You can set location for the debug log by `Edit Menu -> Preferences -> Protocols -> LIGHTNING`. (~/.eclair/eclair.log by default)
 
 ### Ptarmigan
+
 You need to build ptarmigan with developer mode enabled.
+
 ```bash
 sed -i 's/ENABLE_DEVELOPER_MODE=0/ENABLE_DEVELOPER_MODE=1/g' options.mak
 make full
@@ -79,13 +87,15 @@ ptarmigan dumps decryption keys to there.
 
 ```bash
 mkdir ~/.cache/ptarmigan
-export LIGHTNINGKEYLOGFILE=~/.cache/ptarmigan/keys.log 
+export LIGHTNINGKEYLOGFILE=~/.cache/ptarmigan/keys.log
 ```
 
 You should set `$LIGHTNINGKEYLOGFILE` value and `Protocols -> LIGHTNING -> Key log file` preference same. (~/.cache/ptarmigan/keys.log by default)
 
 ### lnd (beta)
+
 You have to start lnd at your $HOME.
+
 ```bash
 go get -d github.com/lightningnetwork/lnd
 cd $GOPATH/src/github.com/lightningnetwork/lnd
@@ -96,8 +106,11 @@ make && make install
 ```
 
 ## Status
+
 ### Supported implementations
+
 Currently, lightning-dissector can decrypt messages sent from
+
 - c-lightning
 - lnd
 - eclair

--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ index afe8dae6e2..81e1e74a60 100644
 ```
 
 ## Setup
+
+### Setup TCP ports (optional)
+
+On Bitcoin mainnet or testnet, your lightning node will always bind to TCP port 9735.
+In that case you don't need to configure anything, by default the dissector will inspect port 9735.
+
+However, if you're running some tests on a local network and have nodes binding to other ports than 9735,
+you need to configure the dissector to inspect those ports.
+
+Go to `Edit Menu -> Preferences -> Protocols -> LIGHTNING` to change the ports inspected by the dissector.
+
 ### c-lightning (beta)
 ```bash
 git clone https://github.com/arowser/lightning -b dissector


### PR DESCRIPTION
The plugin currently hard-codes that the only port used by the lightning protocol is 9735.
This is rather limiting when we want to debug test instances on a local network, where we might have multiple nodes running on the same machine.

This pull request enables users to configure additional ports to inspect to fix that. The default is still to inspect port 9735, so it shouldn't break anything for existing users that only use port 9735.
